### PR TITLE
Better table header/border unicode char selection

### DIFF
--- a/markdown-ts-appear.el
+++ b/markdown-ts-appear.el
@@ -1641,11 +1641,21 @@ The value has the same form as `markdown-ts-appear-link-icon'."
                   (goto-char (treesit-node-start row))
                   (skip-chars-forward " \t" row-end)
                   (point)))
+               (content-end
+                (save-excursion
+                  (goto-char row-end)
+                  (skip-chars-backward " \t" content-start)
+                  (point)))
                (pos (max start content-start))
                (end (min limit row-end)))
           (while (< pos end)
             (markdown-ts-appear--decorate
-             pos (1+ pos) (if (eq (char-after pos) ?|) "┼" "─")
+             pos (1+ pos)
+             (if (eq (char-after pos) ?|)
+                 (cond ((eq pos content-start) "├")
+                       ((eq pos (1- content-end)) "┤")
+                       (t "┼"))
+               "─")
              'markdown-ts-appear-table-border)
             (setq pos (1+ pos))))
       (dolist (pipe (markdown-ts-appear--table-pipes row))

--- a/test/markdown-ts-appear-test.el
+++ b/test/markdown-ts-appear-test.el
@@ -1074,8 +1074,12 @@
     (should (equal (get-text-property 1 'display) "│"))
     (goto-char (point-min))
     (search-forward "|:--------")
-    (should (equal (get-text-property (match-beginning 0) 'display) "┼"))
+    (should (equal (get-text-property (match-beginning 0) 'display) "├"))
     (should (equal (get-text-property (1+ (match-beginning 0)) 'display) "─"))
+    (search-forward "|")
+    (should (equal (get-text-property (1- (point)) 'display) "┼"))
+    (search-forward "|")
+    (should (equal (get-text-property (1- (point)) 'display) "┤"))
     (goto-char (point-min))
     (search-forward "Element")
     (markdown-ts-appear--update)
@@ -1092,13 +1096,17 @@
 
 (ert-deftest markdown-ts-appear-test-preserves-table-indentation ()
   (markdown-ts-appear-test--with-buffer
-      "  | A | B |\n  |---|---|\n  | 1 | 2 |\n"
+      "  | A | B |\n  |---|---| \t\n  | 1 | 2 |\n"
     (goto-char (point-min))
     (forward-line 1)
     (should-not (get-text-property (point) 'display))
     (should-not (get-text-property (1+ (point)) 'display))
     (search-forward "|")
-    (should (equal (get-text-property (1- (point)) 'display) "┼"))))
+    (should (equal (get-text-property (1- (point)) 'display) "├"))
+    (search-forward "|")
+    (should (equal (get-text-property (1- (point)) 'display) "┼"))
+    (search-forward "|")
+    (should (equal (get-text-property (1- (point)) 'display) "┤"))))
 
 (ert-deftest markdown-ts-appear-test-block-fontifiers-respect-region ()
   (markdown-ts-appear-test--with-buffer


### PR DESCRIPTION
Use the same characters as org-appear where the header line intersects the left or right table border.

Fixes: #2